### PR TITLE
[depends] Reduce data sizes and increase loops count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/
 
 # Code coverage
 *.lst
+app

--- a/dub.json
+++ b/dub.json
@@ -13,8 +13,8 @@
 		"mir-random": "~>2.2.11",
 		"mir-blas": "~>1.1.9"
 	},
-	"dflags-ldc": ["-mcpu=native"],
-	"subConfigurations": {"mir-blas": "twolib"},
+    "dflags-ldc": ["-mcpu=native"],
+    "subConfigurations": {"mir-blas": "twolib", "comment": "Also try MKL like 'mkl-tbb-thread'"},
 	"buildTypes": {
 		"release": {
 			"buildOptions": ["releaseMode", "inline", "optimize"],

--- a/other_benchmarks/basic_ops_bench.py
+++ b/other_benchmarks/basic_ops_bench.py
@@ -31,22 +31,22 @@ def functions(nruns=1):
     float_arrayB = np.random.rand(rows * cols)
 
     funcs = dd(list)
-    name = "Element-wise sum of two {}x{} matrices (int), (500 loops)".format(
+    name = "Element-wise sum of two {}x{} matrices (int), (1000 loops)".format(
         int(rows / reduceRowsBy), int(cols / reduceColsBy)
     )
     for _ in range(nruns):
         start = timer()
-        for _ in range(500):
+        for _ in range(1000):
             _ = small_int_matrixA + small_int_matrixB
         end = timer()
         funcs[name].append(end - start)
 
-    name = "Element-wise multiplication of two {}x{} matrices (float64), (500 loops)".format(
+    name = "Element-wise multiplication of two {}x{} matrices (float64), (1000 loops)".format(
         int(rows / reduceRowsBy), int(cols / reduceColsBy)
     )
     for _ in range(nruns):
         start = timer()
-        for _ in range(500):
+        for _ in range(1000):
             _ = small_float_matrixA * small_float_matrixB
         end = timer()
         funcs[name].append(end - start)

--- a/other_benchmarks/basic_ops_bench.py
+++ b/other_benchmarks/basic_ops_bench.py
@@ -10,7 +10,7 @@ def allocation_and_functions():
 
 
 def functions(nruns=1):
-    rows, cols = 5000, 6000
+    rows, cols = 500, 600
     reduceRowsBy, reduceColsBy = 5, 6
 
     small_int_matrixA = np.random.randint(
@@ -31,22 +31,22 @@ def functions(nruns=1):
     float_arrayB = np.random.rand(rows * cols)
 
     funcs = dd(list)
-    name = "Element-wise sum of two {}x{} matrices (int), (50 loops)".format(
+    name = "Element-wise sum of two {}x{} matrices (int), (500 loops)".format(
         int(rows / reduceRowsBy), int(cols / reduceColsBy)
     )
     for _ in range(nruns):
         start = timer()
-        for _ in range(50):
+        for _ in range(500):
             _ = small_int_matrixA + small_int_matrixB
         end = timer()
         funcs[name].append(end - start)
 
-    name = "Element-wise multiplication of two {}x{} matrices (float64), (50 loops)".format(
+    name = "Element-wise multiplication of two {}x{} matrices (float64), (500 loops)".format(
         int(rows / reduceRowsBy), int(cols / reduceColsBy)
     )
     for _ in range(nruns):
         start = timer()
-        for _ in range(50):
+        for _ in range(500):
             _ = small_float_matrixA * small_float_matrixB
         end = timer()
         funcs[name].append(end - start)

--- a/other_benchmarks/basic_ops_bench.scala
+++ b/other_benchmarks/basic_ops_bench.scala
@@ -1,8 +1,8 @@
 import util.Random.nextInt
 
 class BenchmarkOps {
-  final val rows = 5000
-  final val cols = 6000
+  final val rows = 500
+  final val cols = 600
 
   def getRandomIntMatrix: Array[Array[Int]] =
     Array.fill(rows, cols) {

--- a/source/d_benchmarks/mir_ops_bench.d
+++ b/source/d_benchmarks/mir_ops_bench.d
@@ -103,7 +103,7 @@ long[][string] functions(in int nruns = 10)
     long[][string] funcs;
 
     /// Element-wise sum of two int Slices.
-    string name0 = format("Element-wise sum of two [%sx%s] slices (int), (500 loops)",
+    string name0 = format("Element-wise sum of two [%sx%s] slices (int), (1000 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
@@ -114,7 +114,7 @@ long[][string] functions(in int nruns = 10)
         // In numpy you can either use builtin C funcitons
         // or reuse memory by runing slow python loops.
         auto res = smallIntMatrixA.shape.slice!int;
-        for (int j; j < 500; ++j)
+        for (int j; j < 1000; ++j)
         {
             // zero memory allocation
             res[] = smallIntMatrixA * smallIntMatrixB; // can be any element-wise math expression
@@ -124,7 +124,7 @@ long[][string] functions(in int nruns = 10)
     }
 
     /// Element-wise multiplication of two double Slices.
-    string name1 = format("Element-wise multiplication of two [%sx%s] slices (double), (500 loops)",
+    string name1 = format("Element-wise multiplication of two [%sx%s] slices (double), (1000 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
@@ -132,7 +132,7 @@ long[][string] functions(in int nruns = 10)
         sw.start;
         // ditto, see comment for Element-wise sum of two int Slices.
         auto res = smallMatrixA.shape.slice!double;
-        for (int j; j < 500; ++j)
+        for (int j; j < 1000; ++j)
         {
             // zero memory allocation
             res[] = smallMatrixA * smallMatrixB; // can be any element-wise math expression

--- a/source/d_benchmarks/mir_ops_bench.d
+++ b/source/d_benchmarks/mir_ops_bench.d
@@ -75,8 +75,8 @@ long[][string] functions(in int nruns = 10)
     __gshared double gsharedRes2;
 
     auto sw = StopWatch(AutoStart.no);
-    const rows = 5000;
-    const cols = 6000;
+    const rows = 500;
+    const cols = 600;
     const reduceRowsBy = 5;
     const reduceColsBy = 6;
 
@@ -103,7 +103,7 @@ long[][string] functions(in int nruns = 10)
     long[][string] funcs;
 
     /// Element-wise sum of two int Slices.
-    string name0 = format("Element-wise sum of two [%sx%s] slices (int), (50 loops)",
+    string name0 = format("Element-wise sum of two [%sx%s] slices (int), (500 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
@@ -114,7 +114,7 @@ long[][string] functions(in int nruns = 10)
         // In numpy you can either use builtin C funcitons
         // or reuse memory by runing slow python loops.
         auto res = smallIntMatrixA.shape.slice!int;
-        for (int j; j < 50; ++j)
+        for (int j; j < 500; ++j)
         {
             // zero memory allocation
             res[] = smallIntMatrixA * smallIntMatrixB; // can be any element-wise math expression
@@ -124,7 +124,7 @@ long[][string] functions(in int nruns = 10)
     }
 
     /// Element-wise multiplication of two double Slices.
-    string name1 = format("Element-wise multiplication of two [%sx%s] slices (double), (50 loops)",
+    string name1 = format("Element-wise multiplication of two [%sx%s] slices (double), (500 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
@@ -132,7 +132,7 @@ long[][string] functions(in int nruns = 10)
         sw.start;
         // ditto, see comment for Element-wise sum of two int Slices.
         auto res = smallMatrixA.shape.slice!double;
-        for (int j; j < 50; ++j)
+        for (int j; j < 500; ++j)
         {
             // zero memory allocation
             res[] = smallMatrixA * smallMatrixB; // can be any element-wise math expression

--- a/source/d_benchmarks/standard_ops_bench.d
+++ b/source/d_benchmarks/standard_ops_bench.d
@@ -190,8 +190,8 @@ long[][string] functions(in int nruns = 10)
     const reduceRowsBy = 5;
     const reduceColsBy = 6;
 
-    const dotRows = 1000;
-    const dotCols = 500;
+    const dotRows = rows;
+    const dotCols = cols;
 
     int[][] smallIntArrOfArraysA = getRandomAArray!int(10, rows / reduceRowsBy, cols / reduceColsBy);
     int[][] smallIntArrOfArraysB = getRandomAArray!int(10, rows / reduceRowsBy, cols / reduceColsBy);
@@ -219,13 +219,13 @@ long[][string] functions(in int nruns = 10)
     auto matrixD = Matrix!double(rows, cols, getRandomArray!double(1.0, rows * cols));
 
     long[][string] funcs;
-    string name0 = format("Element-wise sum of two [%sx%s] arrays of arrays (int), (50 loops)",
+    string name0 = format("Element-wise sum of two [%sx%s] arrays of arrays (int), (1000 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 500; ++j)
+        for (int j; j < 1000; ++j)
         {
             int[][] res = elementWiseOP!int(OPS.sum, smallIntArrOfArraysA, smallIntArrOfArraysB);
         }
@@ -233,13 +233,13 @@ long[][string] functions(in int nruns = 10)
         funcs[name0] ~= sw.peek.total!"nsecs";
     }
 
-    string name1 = format("Element-wise multiplication of two [%sx%s] arrays of arrays (double), (50 loops)",
+    string name1 = format("Element-wise multiplication of two [%sx%s] arrays of arrays (double), (1000 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 500; ++j)
+        for (int j; j < 1000; ++j)
         {
             double[][] res = elementWiseOP!double(OPS.mul, smallArrOfArraysA, smallArrOfArraysB);
         }
@@ -247,13 +247,13 @@ long[][string] functions(in int nruns = 10)
         funcs[name1] ~= sw.peek.total!"nsecs";
     }
 
-    string name2 = format("Element-wise sum of two [%sx%s] struct matrices (int), (50 loops)",
+    string name2 = format("Element-wise sum of two [%sx%s] struct matrices (int), (1000 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 500; ++j)
+        for (int j; j < 1000; ++j)
         {
             auto res = matrixElementWiseOp!int(OPS.sum, smallIntMatrixA, smallIntMatrixB).to2D;
         }
@@ -261,13 +261,13 @@ long[][string] functions(in int nruns = 10)
         funcs[name2] ~= sw.peek.total!"nsecs";
     }
 
-    string name3 = format("Element-wise multiplication of two [%sx%s] struct matrices (double), (50 loops)",
+    string name3 = format("Element-wise multiplication of two [%sx%s] struct matrices (double), (1000 loops)",
             rows / reduceRowsBy, cols / reduceColsBy);
     for (int i; i < nruns; ++i)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 500; ++j)
+        for (int j; j < 1000; ++j)
         {
             auto res = matrixElementWiseOp!double(OPS.mul, smallMatrixA, smallMatrixB).to2D;
         }

--- a/source/d_benchmarks/standard_ops_bench.d
+++ b/source/d_benchmarks/standard_ops_bench.d
@@ -185,8 +185,8 @@ void reportTime(StopWatch sw, string msg)
 long[][string] functions(in int nruns = 10)
 {
     auto sw = StopWatch(AutoStart.no);
-    const rows = 5000;
-    const cols = 6000;
+    const rows = 500;
+    const cols = 600;
     const reduceRowsBy = 5;
     const reduceColsBy = 6;
 
@@ -225,7 +225,7 @@ long[][string] functions(in int nruns = 10)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 50; ++j)
+        for (int j; j < 500; ++j)
         {
             int[][] res = elementWiseOP!int(OPS.sum, smallIntArrOfArraysA, smallIntArrOfArraysB);
         }
@@ -239,7 +239,7 @@ long[][string] functions(in int nruns = 10)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 50; ++j)
+        for (int j; j < 500; ++j)
         {
             double[][] res = elementWiseOP!double(OPS.mul, smallArrOfArraysA, smallArrOfArraysB);
         }
@@ -253,7 +253,7 @@ long[][string] functions(in int nruns = 10)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 50; ++j)
+        for (int j; j < 500; ++j)
         {
             auto res = matrixElementWiseOp!int(OPS.sum, smallIntMatrixA, smallIntMatrixB).to2D;
         }
@@ -267,7 +267,7 @@ long[][string] functions(in int nruns = 10)
     {
         sw.reset;
         sw.start;
-        for (int j; j < 50; ++j)
+        for (int j; j < 500; ++j)
         {
             auto res = matrixElementWiseOp!double(OPS.mul, smallMatrixA, smallMatrixB).to2D;
         }

--- a/source/d_benchmarks/standard_ops_bench.d
+++ b/source/d_benchmarks/standard_ops_bench.d
@@ -328,7 +328,8 @@ void runStandardBenchmarks()
 {
     writeln("---[Standard D]---");
     auto timings = functions(20);
-    foreach (pair; timings.byKeyValue)
+    import mir.series; // for sorted output
+    foreach (pair; timings.series)
     {
         // convert nsec. to sec. and compute the average
         const double secs = pair.value.map!(a => a / pow(1000.0, 3)).sum / pair.value.length;


### PR DESCRIPTION
3 x 5000x6000 matrixes unlikely feet into L3 CPU cache.
The sizes are so big that any code spends more time fetching the data memory instead of performing the computation itself.

Reducing matrixes size will enlarge the speed ratio between speed and slow code. Currently, this ratio is very limited by memory caching.

This MR includes the previous one.

---
Update:
This MR is just for reference, it isn't ideal. 

The logic is the following.
For example, let take a scalar product function. If it is tested with 5000x6000 matrixes, then it needs to access 480 MB of memory, while the target CPU has only 6 MBs L3. Also, part of L3 is used by
1. Phobos's associative arrays that are used in the loop to store the timing.
2. Program code (AA and the loop itself)
3. Phobos/System code for time measurement.
